### PR TITLE
Fix BK moves ending up in wrong state after connecting to AP

### DIFF
--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -237,7 +237,14 @@ function onClear(slot_data)
         local obj = Tracker:FindObjectForCode("randomizebkmoves")
         local stage = slot_data['bk_moves']
         if stage then
-            obj.CurrentStage = stage
+            if obj.CurrentStage == stage then
+                -- we need to manually call toggleBKMoves
+                -- because onClear will reset the bk moves to off via item mappings
+                -- and "randomizebkmoves" change does not change
+                toggleBKMoves()
+            else
+                obj.CurrentStage = stage
+            end
         end
     end
 


### PR DESCRIPTION
Fix BK moves ending up in wrong state after connecting to AP due to ``randomizebkmoves`` not changing state and therefore not calling ``toggleBKMoves``. This happens because ``onClear`` resets the BK move items to off via the item mapping but when connecting to AP from a loaded state ``randomizebkmoves`` might already be in the correct state. This fix works around this by explicitly calling ``toggleBKMoves`` when ``randomizebkmoves`` does not change state in ``onClear``.

Example repro for this issue:
- With randomize BK moves disabled connect to a AP room
- disconnect AP
- connected again
- BK move items are now all disabled
