### PR TITLE
Remove wrong early return in onClear

### DIFF
--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -275,7 +275,6 @@ function onClear(slot_data)
                 first_level = k
             end
         end
-        return first_level
     end
 
     --print(dump_table(slot_data))


### PR DESCRIPTION
This early return would stop auto map tracking from working