### PR TITLE
v0.10.1

### DIFF
--- a/locations/locations_regions.json
+++ b/locations/locations_regions.json
@@ -585,8 +585,7 @@
   {
     "name": "Region: Hailfire Peaks - Icy Side",
     "access_rules": [
-      "@Region: Hailfire Peaks - Lava Side",
-      "@Region: Hailfire Peaks - Icy Side Boss"
+      "@Region: Hailfire Peaks - Lava Side"
     ]
   },
   {
@@ -631,28 +630,28 @@
     "name": "Region: Mayahem Temple - Boss",
     "access_rules": [
       "@Region: Mayahem Temple - Inside Targitzan's Temple, ^$connector_MTTT_to_MTBoss",
-      "$load_boss_tdl_mt, @Region: Boss Arena - Terry, ^$connector_Terry_to_MTBoss"
+      "$load_boss_mt_tdl, @Region: Boss Arena - Terry, ^$connector_Terry_to_MTBoss"
     ]
   },
   {
     "name": "Region: Glitter Gulch Mine - Boss",
     "access_rules": [
       "@Region: Inside Chuffy",
-      "$load_boss_tdl_ggm, @Region: Boss Arena - Terry, ^$connector_Terry_to_GGMBoss"
+      "$load_boss_ggm_tdl, @Region: Boss Arena - Terry, ^$connector_Terry_to_GGMBoss"
     ]
   },
   {
     "name": "Region: Witchyworld - Boss",
     "access_rules": [
       "@Region: Witchyworld - Main Area",
-      "$load_boss_tdl_ww, @Region: Boss Arena - Terry"
+      "$load_boss_ww_tdl, @Region: Boss Arena - Terry"
     ]
   },
   {
     "name": "Region: Jolly Roger's Lagoon - Boss",
     "access_rules": [
       "@Region: Jolly Roger's Lagoon - Locker Cavern, ^$connector_JRLLC_to_JRLBoss",
-      "$load_boss_tdl_jrl, @Region: Boss Arena - Terry"
+      "$load_boss_jrl_tdl, @Region: Boss Arena - Terry"
     ]
   },
   {
@@ -666,28 +665,28 @@
     "name": "Region: Grunty Industries - Boss",
     "access_rules": [
       "@Region: Grunty Industries 1st Floor, ^$connector_GIF1_to_GIBoss",
-      "$load_boss_tdl_gi, @Region: Boss Arena - Terry"
+      "$load_boss_gi_tdl, @Region: Boss Arena - Terry"
     ]
   },
   {
     "name": "Region: Hailfire Peaks - Lava Side Boss",
     "access_rules": [
       "@Region: Hailfire Peaks - Lava Side, ^$connector_HFPL_to_HFPLBoss",
-      "$load_boss_tdl_hfpl, @Region: Boss Arena - Terry"
+      "$load_boss_hfpl_tdl, @Region: Boss Arena - Terry"
     ]
   },
   {
     "name": "Region: Hailfire Peaks - Icy Side Boss",
     "access_rules": [
       "@Region: Hailfire Peaks - Icy Side, ^$connector_HFPI_to_HFPIBoss",
-      "$load_boss_tdl_hfpi, @Region: Boss Arena - Terry"
+      "$load_boss_hfpi_tdl, @Region: Boss Arena - Terry"
     ]
   },
   {
     "name": "Region: Cloud Cuckooland - Boss",
     "access_rules": [
       "@Region: Cloud Cuckooland",
-      "$load_boss_tdl_ccl, @Region: Boss Arena - Terry"
+      "$load_boss_ccl_tdl, @Region: Boss Arena - Terry"
     ]
   },
   

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Banjo-Tooie",
     "game_name": "Banjo-Tooie",
-    "package_version": "0.10.0",
+    "package_version": "0.10.1",
     "package_uid": "ap_banjotooie",
     "author": "Ozone, MiaSchemes",
     "variants": {

--- a/scripts/logic/logic__glittergulch.lua
+++ b/scripts/logic/logic__glittergulch.lua
@@ -72,19 +72,15 @@ end
 function access_GGM_canBreakBoulders(skip)
     local logic = 99
     --[[        GM_boulders
-    return (self.bill_drill(state) and self.small_elevation(state)) or self.humbaGGM(state)
-    --]]
-    
-    -- FIXIT absolutely none of the boulders need small elevation
+     return self.bill_drill(state) or self.humbaGGM(state)
+     --]]
     -- FIXIT also every single if statement in glitter gulch mine that checks for small elevation should check for alternatives (eg. smuggling springy step shoes)
     
     local humba = access_GGM_humba(true)
     
     -- Normal Logic
-    if ( has_billDrill() and can_reachSmallElevation() or humba <= logictype.CurrentStage ) then
+    if ( has_billDrill() or humba <= logictype.CurrentStage ) then
         logic = 0
-    elseif ( has_billDrill() ) then
-        logic = 7
     
     -- Sequence Breaking
     else

--- a/scripts/logic/logic__gruntyindustries.lua
+++ b/scripts/logic/logic__gruntyindustries.lua
@@ -82,22 +82,17 @@ function access_GI_floor2SplitUp(skip)
         logic = 0 -- Normal Logic
     elseif ( has("splitup") and explosives < 2 ) then
         logic = 1 -- Sequence Breaking
-    elseif ( has("clawbts") and extremelyLongJump <= logictype.CurrentStage ) then
+    elseif ( has("splitup") and has("clawbts") and extremelyLongJump <= logictype.CurrentStage ) then
         logic = 2 -- Normal Logic
     
     -- Sequence Breaking
-    elseif ( has("splitup") or has("clawbts") ) then
-        local splitup = 99
-        if ( has("splitup") ) then
-            splitup = explosives
-        end
-        
+    elseif ( has("splitup") ) then
         local clawbts = 99
         if ( has("splitup") ) then
             clawbts = extremelyLongJump
         end
         
-        logic = math.min(splitup, clawbts)
+        logic = math.min(explosives, clawbts)
     end
     
     return convertLogic(logic, skip)
@@ -731,7 +726,7 @@ function jiggy_GI_guarded(skip)
                 and (self.spring_pad(state) or self.wing_whack(state) or self.glide(state))\
                 and (self.tall_jump(state) or self.leg_spring(state))
     elif self.world.options.logic_type == LogicType.option_easy_tricks:
-        logic = self.split_up(state) and\
+        logic = self.split_up(state) and (self.tall_jump(state) or self.leg_spring(state)) and\
                 ((self.claw_clamber_boots(state) or state.can_reach_region(regionName.GI2, self.player)) and self.spring_pad(state)\
                     or self.claw_clamber_boots(state) and (self.wing_whack(state) or self.glide(state)) and (self.egg_aim(state) or self.wing_whack(state))\
                     or self.leg_spring(state) and self.glide(state) and (self.egg_aim(state) or self.wing_whack(state)))\
@@ -1347,7 +1342,7 @@ end
 function nests_GI_floor1TopPipe(skip)
     local logic = 99
     --[[        nest_gi_floor1_top_pipe
-    if self.world.options.logic_type == LogicType.option_intended:
+     if self.world.options.logic_type == LogicType.option_intended:
         logic = self.split_up(state) and self.claw_clamber_boots(state) and (self.spring_pad(state) or self.wing_whack(state) or (self.egg_aim(state) and self.glide(state)))
     elif self.world.options.logic_type == LogicType.option_easy_tricks:
         logic = self.split_up(state) and\
@@ -1355,16 +1350,13 @@ function nests_GI_floor1TopPipe(skip)
                     or self.claw_clamber_boots(state) and (self.wing_whack(state) or self.glide(state)) and (self.egg_aim(state) or self.wing_whack(state)))
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
         logic = self.split_up(state) and\
-                ((self.claw_clamber_boots(state) or state.can_reach_region(regionName.GI2, self.player)) and self.spring_pad(state)\
-                    or self.claw_clamber_boots(state) and (self.wing_whack(state) or self.glide(state)) and (self.egg_aim(state) or self.wing_whack(state)))
+                (self.claw_clamber_boots(state) or state.can_reach_region(regionName.GI2, self.player) and self.floor_2_split_up(state))
     elif self.world.options.logic_type == LogicType.option_glitches:
         logic = self.split_up(state) and\
-                ((self.claw_clamber_boots(state) or state.can_reach_region(regionName.GI2, self.player)) and self.spring_pad(state)\
-                    or self.claw_clamber_boots(state) and (self.wing_whack(state) or self.glide(state)) and (self.egg_aim(state) or self.wing_whack(state)))
-    --]]
+                (self.claw_clamber_boots(state) or state.can_reach_region(regionName.GI2, self.player) and self.floor_2_split_up(state))
+     --]]
     
     local gi2Accessibility = Tracker:FindObjectForCode("@Region: Grunty Industries 2nd Floor").AccessibilityLevel
-    local outsideToBack = connector_GIO_to_GIOBack(true)
     local floor2SplitUp = access_GI_floor2SplitUp(true)
     
     -- Normal Logic
@@ -1372,10 +1364,14 @@ function nests_GI_floor1TopPipe(skip)
         logic = 0
     elseif ( has("splitup") and has("tjump") and (gi2Accessibility == AccessibilityLevel.Normal or gi2Accessibility == AccessibilityLevel.Cleared) ) then
         logic = 1
+    elseif ( has("splitup") and (has("clawbts") or (gi2Accessibility == AccessibilityLevel.Normal or gi2Accessibility == AccessibilityLevel.Cleared) and floor2SplitUp <= logictype.CurrentStage) ) then
+        logic = 2
     
     -- Sequence Breaking
-    elseif ( has("splitup") and has("tjump") and gi2Accessibility > AccessibilityLevel.None ) then
-        logic = logictype.CurrentStage + 1
+    elseif ( has("splitup") and (gi2Accessibility == AccessibilityLevel.Normal or gi2Accessibility == AccessibilityLevel.Cleared) ) then
+        logic = math.max(2, floor2SplitUp)
+    elseif ( has("splitup") and gi2Accessibility > AccessibilityLevel.None ) then
+        logic = math.max(2, floor2SplitUp, logictype.CurrentStage + 1)
     end
     
     return convertLogic(logic, skip)
@@ -1391,11 +1387,11 @@ function nests_GI_floor1HighPipe(skip)
                 or state.can_reach_region(regionName.GI2, self.player) and (self.floor_2_split_up(state) and self.leg_spring(state) or self.F2_to_F1(state) and self.spring_pad(state))\
                 or self.claw_clamber_boots(state) and (self.wing_whack(state) or self.glide(state)) and (self.egg_aim(state) or self.wing_whack(state))
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
-        logic = self.claw_clamber_boots(state) and (self.leg_spring(state) or self.spring_pad(state) or self.clockwork_shot(state))\
+        logic = self.claw_clamber_boots(state)\
                 or state.can_reach_region(regionName.GI2, self.player) and (self.floor_2_split_up(state) and self.leg_spring(state) or self.F2_to_F1(state) and (self.spring_pad(state) or self.clockwork_shot(state)))\
                 or self.claw_clamber_boots(state) and (self.wing_whack(state) or self.glide(state)) and (self.egg_aim(state) or self.wing_whack(state))
     elif self.world.options.logic_type == LogicType.option_glitches:
-        logic = self.claw_clamber_boots(state) and (self.leg_spring(state) or self.spring_pad(state) or self.clockwork_shot(state))\
+        logic = self.claw_clamber_boots(state)\
                 or state.can_reach_region(regionName.GI2, self.player) and (self.floor_2_split_up(state) and self.leg_spring(state) or self.F2_to_F1(state) and (self.spring_pad(state) or self.clockwork_shot(state)))\
                 or self.claw_clamber_boots(state) and (self.wing_whack(state) or self.glide(state)) and (self.egg_aim(state) or self.wing_whack(state))
     --]]
@@ -1409,6 +1405,8 @@ function nests_GI_floor1HighPipe(skip)
         logic = 0
     elseif ( (gi2Accessibility == AccessibilityLevel.Normal or gi2Accessibility == AccessibilityLevel.Cleared) and (floor2SplitUp <= logictype.CurrentStage and has_legSpring() or f2tof1 <= logictype.CurrentStage and has("tjump")) or has("clawbts") and (has_wingWhack() or has_glide() and has("eggaim")) ) then
         logic = 1
+	elseif ( has("clawbts") ) then
+        logic = 2
     
     -- Sequence Breaking
     elseif ( gi2Accessibility == AccessibilityLevel.Normal or gi2Accessibility == AccessibilityLevel.Cleared ) then

--- a/scripts/logic/logic__hailfire.lua
+++ b/scripts/logic/logic__hailfire.lua
@@ -307,12 +307,12 @@ function warp_HFP_icicleGrotto(skip)
                 or self.warp_to_icicle_grotto(state)
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
         logic = self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state))\
-                or self.hfp_top(state) and self.spring_pad(state) and self.talon_trot(state)\
+                or self.hfp_top(state) and (self.talon_trot(state) or self.claw_clamber_boots(state))\
                 or (self.extremelyLongJump(state) and self.clockwork_shot(state))\
                 or self.warp_to_icicle_grotto(state)
     elif self.world.options.logic_type == LogicType.option_glitches:
         logic = self.split_up(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state))\
-                or self.hfp_top(state) and self.spring_pad(state) and self.talon_trot(state)\
+                or self.hfp_top(state) and (self.talon_trot(state) or self.claw_clamber_boots(state))\
                 or (self.extremelyLongJump(state) and self.clockwork_shot(state))\
                 or self.warp_to_icicle_grotto(state)
     --]]
@@ -328,14 +328,14 @@ function warp_HFP_icicleGrotto(skip)
         logic = 1
     elseif ( top < 2 and has("tjump") and (has("ttrot") or has("splitup")) or warpToGrotto < 2 ) then
         logic = 1 -- Sequence Breaking
-    elseif ( extremelyLongJump <= logictype.CurrentStage and can_clockworkShot() ) then
+    elseif ( extremelyLongJump <= logictype.CurrentStage and can_clockworkShot() or top <= logictype.CurrentStage and (has("ttrot") or has("clawbts")) ) then
         logic = 2
     
     -- Sequence Breaking
     else
         local fromTop = 99
-        if ( has("tjump") and has("ttrot") or has("tjump") and has("splitup") or has("warphp5") and (has("warphp2") or has("warphp3") or has("warphp4")) ) then
-            fromTop = top
+        if ( has("ttrot") or has("clawbts") ) then
+            fromTop = math.max(2, top)
         end
         
         local clockwork = 99
@@ -343,12 +343,7 @@ function warp_HFP_icicleGrotto(skip)
             clockwork = math.max(2, extremelyLongJump)
         end
         
-        local newTrick = 99
-        if ( top <= 7 and has("ttrot") ) then
-            newTrick = 7 -- jump up using icicles
-        end
-        
-        logic = math.min(fromTop, clockwork, newTrick)
+        logic = math.min(fromTop, clockwork)
     end
     
     return convertLogic(logic, skip)
@@ -428,12 +423,12 @@ function jiggy_HFP_dragonBrothers(skip)
     
     local hfpiAccessibility = Tracker:FindObjectForCode("@Region: Hailfire Peaks - Icy Side").AccessibilityLevel
     
-    if ( has("feggs") and has("ieggs") and has("clawbts") and has("fpad") and has("eggshoot") and has("climb") and (has("tjump") or has("ttrot")) and (hfpiAccessibility == AccessibilityLevel.Normal or hfpiAccessibility == AccessibilityLevel.Cleared) ) then
+    if ( has("feggs") and has("ieggs") and has("eggshoot") and has("climb") and (has("tjump") or has("ttrot")) and (hfpiAccessibility == AccessibilityLevel.Normal or hfpiAccessibility == AccessibilityLevel.Cleared) ) then
         logic = 0
-    elseif ( has("feggs") and has("ieggs") and has("clawbts") and has("fpad") and has("eggshoot") and (has("fflip") or has("ggrab")) and (has("tjump") or has("ttrot")) and (hfpiAccessibility == AccessibilityLevel.Normal or hfpiAccessibility == AccessibilityLevel.Cleared) ) then
+    elseif ( has("feggs") and has("ieggs") and has("eggshoot") and (has("fflip") or has("ggrab")) and (has("tjump") or has("ttrot")) and (hfpiAccessibility == AccessibilityLevel.Normal or hfpiAccessibility == AccessibilityLevel.Cleared) ) then
         logic = 1
     elseif ( has("randomizebossentrances_off") and has("feggs") and has("ieggs") and has("fpad") and has("eggshoot") and has_packWhack() and (has("tjump") or has("ttrot")) and (has("climb") or has("fflip") or has("ggrab")) and (has("clawbts") or (has("tjump") and has("roll") or has("ttrot")) and (has("flutter") or has("arat")) and has("ggrab")) ) then
-        logic = 2  -- I don't think this if statement will ever be hit
+        logic = 2
     end
     
     return convertLogic(logic, skip)
@@ -632,6 +627,8 @@ function jiggy_HFP_fromStompingPlains(skip)
         logic = 2
     elseif ( (hfpAccessibility == AccessibilityLevel.Normal or hfpAccessibility == AccessibilityLevel.Cleared) and can_clockworkShot() and (has("ttrot") or has("splitup") or has("fflip")) ) then
         logic = 3
+    elseif ( has("splitup") and has_packWhack() ) then
+        logic = 7 -- pack whack replaces tall jump
     
     -- Sequence Breaking
     elseif ( hfpAccessibility > AccessibilityLevel.None and can_clockworkShot() and (has("ttrot") or has("splitup") or has("fflip")) ) then
@@ -1285,7 +1282,7 @@ function nests_HFP_icicleGrottoSpringPad(skip)
                 )
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
         logic = (self.split_up(state) and self.ice_cube_kazooie(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\
-                or (self.hfp_top(state) and (self.spring_pad(state) and self.ice_cube_BK(state) or self.clockwork_shot(state)) and self.talon_trot(state))\
+                or (self.hfp_top(state) and (self.ice_cube_BK(state) or self.clockwork_shot(state)) and (self.talon_trot(state) or self.claw_clamber_boots(state)))\            -- redundant to check for clockwork shot here because ice_cube_BK accounts for it already
                 or (self.extremelyLongJump(state) and self.clockwork_shot(state))\
                 or self.warp_to_icicle_grotto(state) and (
                     self.ice_cube_BK(state)\
@@ -1293,7 +1290,7 @@ function nests_HFP_icicleGrottoSpringPad(skip)
                 )
     elif self.world.options.logic_type == LogicType.option_glitches:
         logic = (self.split_up(state) and self.ice_cube_kazooie(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\
-                or (self.hfp_top(state) and (self.spring_pad(state) and self.ice_cube_BK(state) or self.clockwork_shot(state)) and self.talon_trot(state))\
+                or (self.hfp_top(state) and (self.ice_cube_BK(state) or self.clockwork_shot(state)) and (self.talon_trot(state) or self.claw_clamber_boots(state)))\
                 or (self.extremelyLongJump(state) and self.clockwork_shot(state))\
                 or self.warp_to_icicle_grotto(state) and (
                     self.ice_cube_BK(state)\
@@ -1314,7 +1311,7 @@ function nests_HFP_icicleGrottoSpringPad(skip)
         logic = 1
     elseif ( top < 2 and has("tjump") and (has("ttrot") and pairCube < 2 or kazooieCube < 2) or warpToGrotto < 2 and (pairCube < 2 or kazooieCube < 2) ) then
         logic = 1 -- Sequence Breaking
-    elseif ( can_clockworkShot() and (top <= logictype.CurrentStage and has("ttrot") or extremelyLongJump <= logictype.CurrentStage) ) then
+    elseif ( top <= logictype.CurrentStage and pairCube <= logictype.CurrentStage and (has("ttrot") or has("clawbts")) or can_clockworkShot() and extremelyLongJump <= logictype.CurrentStage ) then
         logic = 2
     
     -- Sequence Breaking
@@ -1330,13 +1327,8 @@ function nests_HFP_icicleGrottoSpringPad(skip)
         end
         
         local pair = 99
-        if ( has("tjump") and has("ttrot") ) then
-            pair = math.max(top, pairCube)
-        end
-        
-        local clockworkTop = 99
-        if ( can_clockworkShot() and has("ttrot") ) then
-            clockworkTop = math.max(2, top)
+        if ( has("ttrot") or has("clawbts") ) then
+            pair = math.max(2, top, pairCube)
         end
         
         local clockworkJump = 99
@@ -1344,12 +1336,7 @@ function nests_HFP_icicleGrottoSpringPad(skip)
             clockworkJump = math.max(2, extremelyLongJump)
         end
         
-        local newTrick = 99
-        if ( top <= 7 and pairCube <= 7 and has("ttrot") ) then
-            newTrick = 7 -- jump up using icicles
-        end
-        
-        logic = math.max(2, math.min(topKazooie, soloKazooie, pair, clockworkTop, clockworkJump, math.max(warpToGrotto, pairCube), math.max(warpToGrotto, kazooieCube), newTrick))
+        logic = math.max(2, math.min(topKazooie, soloKazooie, pair, clockworkJump, math.max(warpToGrotto, pairCube), math.max(warpToGrotto, kazooieCube)))
     end
     
     return convertLogic(logic, skip)
@@ -1888,8 +1875,7 @@ function trainSwitch_HFP_lava(skip)
                     and (self.flutter(state) or self.air_rat_a_tat_rap(state))\
                 or self.flight_pad(state)\
                 or self.leg_spring(state)\
-                or self.split_up(state) and self.tall_jump(state)\
-             or self.talon_trot(state) and self.flutter(state)
+                or self.split_up(state) and self.tall_jump(state)
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
         logic = self.grip_grab(state)\
                     and (self.tall_jump(state) or self.talon_trot(state))\
@@ -1910,8 +1896,10 @@ function trainSwitch_HFP_lava(skip)
     
     if ( has("ggrab") and (has("tjump") or has("ttrot")) and (has("flutter") or has("arat")) ) then
         logic = 0
-    elseif ( has("fpad") or has_legSpring() or has("splitup") and has("tjump") or has("ttrot") and has("flutter") ) then
+    elseif ( has("fpad") or has_legSpring() or has("splitup") and has("tjump") ) then
         logic = 1
+    elseif ( has("ttrot") and has("flutter") ) then
+        logic = 2
     end
     
     return convertLogic(logic, skip)

--- a/scripts/logic/logic__jollyrogers.lua
+++ b/scripts/logic/logic__jollyrogers.lua
@@ -523,40 +523,47 @@ end
 function jiggy_JRL_lordWooFakFak(skip)
     local logic = 99
     --[[        jiggy_lord_woo
-    if self.world.options.logic_type == LogicType.option_intended:
-        logic = self.sub_aqua_egg_aiming(state) and self.grenade_eggs(state)\
-                    and (self.humbaJRL(state) or self.check_mumbo_magic(state, itemName.MUMBOJR))
+     if self.world.options.logic_type == LogicType.option_intended:
+        logic = state.can_reach_region(regionName.JR, self.player) and (
+                    self.sub_aqua_egg_aiming(state) and self.grenade_eggs(state)\
+                    and (self.humbaJRL(state) or state.has(itemName.MUMBOJR, self.player))
+                )
     elif self.world.options.logic_type == LogicType.option_easy_tricks:
-        logic = self.sub_aqua_egg_aiming(state) and self.grenade_eggs(state)\
-                    and (self.humbaJRL(state) or self.check_mumbo_magic(state, itemName.MUMBOJR))
+        logic = state.can_reach_region(regionName.JR, self.player) and (
+                    self.sub_aqua_egg_aiming(state) and self.grenade_eggs(state)\
+                    and (self.humbaJRL(state) or state.has(itemName.MUMBOJR, self.player))
+                )
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
         logic = self.grenade_eggs(state) and self.sub_aqua_egg_aiming(state) and (
                     self.talon_torpedo(state) and self.doubleAir(state)\
-                    or self.check_mumbo_magic(state, itemName.MUMBOJR)\
-                    or self.humbaJRL(state)
+                    or state.can_reach_region(regionName.JR, self.player)\
+                    and (self.humbaJRL(state) or state.has(itemName.MUMBOJR, self.player))
                 )
     elif self.world.options.logic_type == LogicType.option_glitches:
         logic = self.grenade_eggs(state) and self.sub_aqua_egg_aiming(state) and (
                     self.talon_torpedo(state) and self.doubleAir(state)\
-                    or self.check_mumbo_magic(state, itemName.MUMBOJR)\
-                    or self.humbaJRL(state)
+                    or state.can_reach_region(regionName.JR, self.player)\
+                    and (self.humbaJRL(state) or state.has(itemName.MUMBOJR, self.player))
                 )
-    --]]
+     --]]
     
     -- Normal Logic
     if ( has("auqaim") and has("geggs") ) then
+		local jrlAccessibility = Tracker:FindObjectForCode("@Region: Jolly Roger's Lagoon - Main Area").AccessibilityLevel
         local humba = access_JRL_humba(true)
     
-        if ( humba <= logictype.CurrentStage or has("mumbojr") ) then
+        if ( (jrlAccessibility == AccessibilityLevel.Normal or jrlAccessibility == AccessibilityLevel.Cleared) and (humba <= logictype.CurrentStage or has("mumbojr")) ) then
             logic = 0
-        elseif ( humba < 2 ) then
+        elseif ( (jrlAccessibility == AccessibilityLevel.Normal or jrlAccessibility == AccessibilityLevel.Cleared or jrlAccessibility > AccessibilityLevel.None and logictype.CurrentStage == 0) and humba < 2 ) then
             logic = 1 -- Sequence Breaking
         elseif ( has("ttorp") and has("dair") ) then
             logic = 2
         
         -- Sequence Breaking
-        else
+        elseif ( jrlAccessibility == AccessibilityLevel.Normal or jrlAccessibility == AccessibilityLevel.Cleared ) then
             logic = humba
+        elseif ( jrlAccessibility > AccessibilityLevel.None ) then
+            logic = math.max(humba, logictype.CurrentStage + 1)
         end
     end
     

--- a/scripts/logic/logic__terrydactyland.lua
+++ b/scripts/logic/logic__terrydactyland.lua
@@ -715,7 +715,7 @@ function jiggy_TDL_chompa(skip)
         )
     elif self.world.options.logic_type == LogicType.option_easy_tricks:
         logic = self.breegull_blaster(state) and (
-            ((self.tall_jump(state) or self.grip_grab(state)) and self.flight_pad(state)
+            ((self.tall_jump(state) or self.grip_grab(state) or self.beak_buster(state)) and self.flight_pad(state)
              or (self.egg_aim(state) and self.has_explosives(state) and self.springy_step_shoes(state))
              or (self.springy_step_shoes(state) and self.veryLongJump(state)))
         )
@@ -739,7 +739,7 @@ function jiggy_TDL_chompa(skip)
         -- Normal Logic
         if ( (has("tjump") or has("ggrab")) and has("fpad") or has("springb") and has("eggaim") and explosives <= logictype.CurrentStage ) then
             logic = 0
-        elseif ( has("springb") and can_veryLongJump() ) then
+        elseif ( has("springb") and can_veryLongJump() or has("bbust") and has("fpad") ) then
             logic = 1
         elseif ( has("springb") and has("eggaim") and explosives < 2 ) then
             logic = 1 -- Sequence Breaking
@@ -1216,29 +1216,30 @@ end
 function nests_TDL_trainStation(skip)
     local logic = 99
     --[[        enter_tdl_train_station
-    if self.world.options.logic_type == LogicType.option_intended:
+     if self.world.options.logic_type == LogicType.option_intended:
         logic = self.small_elevation(state)\
-                or state.can_reach_region(regionName.CHUFFY, self.player) and state.has(itemName.CHUFFY, self.player) and state.has(itemName.TRAINSWTD, self.player)
+                or state.can_reach_region(regionName.CHUFFY, self.player) and state.has(itemName.TRAINSWTD, self.player) and self.can_beat_king_coal(state)
     elif self.world.options.logic_type == LogicType.option_easy_tricks:
         logic = self.small_elevation(state)\
                 or self.turbo_trainers(state)\
                 or self.springy_step_shoes(state)\
                 or self.beak_buster(state)\
-                or state.can_reach_region(regionName.CHUFFY, self.player) and state.has(itemName.CHUFFY, self.player) and state.has(itemName.TRAINSWTD, self.player)
+                or state.can_reach_region(regionName.CHUFFY, self.player) and state.has(itemName.TRAINSWTD, self.player) and self.can_beat_king_coal(state)
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
         logic = True
     elif self.world.options.logic_type == LogicType.option_glitches:
         logic = True
-    --]]
+     --]]
     
     local chuffyAccessibility = Tracker:FindObjectForCode("@Region: Inside Chuffy").AccessibilityLevel
+    local canBeatKingCoal = chuffy_canBeatKingCoal(true)
     
     -- Normal Logic
-    if ( can_reachSmallElevation() or has("trainswtd") and (chuffyAccessibility == AccessibilityLevel.Normal or chuffyAccessibility == AccessibilityLevel.Cleared) ) then
+    if ( can_reachSmallElevation() or has("trainswtd") and (chuffyAccessibility == AccessibilityLevel.Normal or chuffyAccessibility == AccessibilityLevel.Cleared) and canBeatKingCoal <= logictype.CurrentStage ) then
         logic = 0
     elseif ( has("ttrain") or has("springb") or has("bbust") ) then
         logic = 1
-    elseif ( logictype.CurrentStage == 0 and chuffyAccessibility > AccessibilityLevel.None ) then
+    elseif ( has("trainswtd") and logictype.CurrentStage == 0 and chuffyAccessibility > AccessibilityLevel.None and canBeatKingCoal < 2 ) then
         logic = 1 -- Sequence Breaking
     else
         logic = 2

--- a/scripts/logic/logic__witchyworld.lua
+++ b/scripts/logic/logic__witchyworld.lua
@@ -589,10 +589,10 @@ function jiggy_WW_topOfInferno(skip)
         logic = self.split_up(state) and (self.tall_jump(state) or self.leg_spring(state))\
                 or self.flap_flip(state) and (self.talon_trot(state) or self.turbo_trainers(state))
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
-        logic = self.split_up(state) and (self.tall_jump(state) or self.leg_spring(state))\
+        logic = self.split_up(state)\
                 or self.flap_flip(state) and (self.talon_trot(state) or self.turbo_trainers(state))
     elif self.world.options.logic_type == LogicType.option_glitches:
-        logic = self.split_up(state) and (self.tall_jump(state) or self.leg_spring(state))\
+        logic = self.split_up(state)\
                 or self.flap_flip(state) and (self.talon_trot(state) or self.turbo_trainers(state))
      --]]
     
@@ -601,7 +601,7 @@ function jiggy_WW_topOfInferno(skip)
     elseif ( has_legSpring() or has("fflip") and (has("ttrot") or has("ttrain")) ) then
         logic = 1
     elseif ( has("splitup") ) then
-        logic = 7
+        logic = 2
     end
     
     return convertLogic(logic, skip)
@@ -813,14 +813,14 @@ function nests_WW_pumpRoom(skip)
                 or self.leg_spring(state)\
                 or self.split_up(state) and self.grip_grab(state)\
                 or self.pack_whack(state) and self.tall_jump(state)\
-                or self.clockwork_shot(state) and self.small_elevation(state)
+                or self.clockwork_shot(state) and (self.small_elevation(state) or self.grip_grab(state) or self.beak_buster(state))
                 ) and self.has_explosives(state)
     elif self.world.options.logic_type == LogicType.option_glitches:
         logic = (self.flap_flip(state)\
                 or self.leg_spring(state)\
                 or self.split_up(state) and self.grip_grab(state)\
                 or self.pack_whack(state) and self.tall_jump(state)\
-                or self.clockwork_shot(state) and self.small_elevation(state)
+                or self.clockwork_shot(state) and (self.small_elevation(state) or self.grip_grab(state) or self.beak_buster(state))
                 ) and self.has_explosives(state)
     --]]
     
@@ -831,14 +831,12 @@ function nests_WW_pumpRoom(skip)
         logic = 0
     elseif ( explosives <= logictype.CurrentStage and has_packWhack() and has("tjump") ) then
         logic = 1
-    elseif ( explosives <= logictype.CurrentStage and can_clockworkShot() and can_reachSmallElevation() ) then
+    elseif ( can_clockworkShot() and (can_reachSmallElevation() or has("bbust") or has("ggrab")) ) then
         logic = 2
     
     -- Sequence Breaking
-    elseif ( has("fflip") or has_legSpring() or has("splitup") and has("ggrab") or has_packWhack() and has("tjump") or can_clockworkShot() and can_reachSmallElevation() ) then
-        logic = math.max(2, explosives)
-    elseif ( can_clockworkShot() and (has("bbust") or has("ggrab")) ) then
-        logic = 7 -- FIXIT you can reach the pump room without tall jump if you hug the barrel
+    elseif ( has("fflip") or has_legSpring() or has("splitup") and has("ggrab") or has_packWhack() and has("tjump") ) then
+        logic = math.max(1, explosives)
     end
     
     return convertLogic(logic, skip)
@@ -1206,9 +1204,9 @@ function honeycomb_WW_pumpRoomEntrance(skip)
     elif self.world.options.logic_type == LogicType.option_easy_tricks:
         logic = self.has_explosives(state) and (self.small_elevation(state) or self.split_up(state))
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
-        logic = (self.has_explosives(state) and (self.small_elevation(state) or self.split_up(state))) or self.clockwork_shot(state)
+        logic = (self.has_explosives(state) and (self.small_elevation(state) or self.split_up(state) or self.grip_grab(state) or self.beak_buster(state))) or self.clockwork_shot(state)
     elif self.world.options.logic_type == LogicType.option_glitches:
-        logic = (self.has_explosives(state) and (self.small_elevation(state) or self.split_up(state)))\
+        logic = (self.has_explosives(state) and (self.small_elevation(state) or self.split_up(state) or self.grip_grab(state) or self.beak_buster(state)))\
                 or self.clockwork_shot(state)\
                 or self.pack_whack(state)
     --]]
@@ -1219,7 +1217,7 @@ function honeycomb_WW_pumpRoomEntrance(skip)
         logic = 0 -- Normal Logic
     elseif ( explosives < 2 and (can_reachSmallElevation() or has("splitup")) ) then
         logic = explosives -- Sequence Breaking
-    elseif ( can_clockworkShot() ) then
+    elseif ( can_clockworkShot() or explosives <= logictype.CurrentStage and (has("ggrab") or has("bbust")) ) then
         logic = 2 -- Normal Logic
     elseif ( has_packWhack() ) then
         logic = 3
@@ -1227,8 +1225,6 @@ function honeycomb_WW_pumpRoomEntrance(skip)
     -- Sequence Breaking
     elseif ( can_reachSmallElevation() or has("splitup") ) then
         logic = explosives
-    elseif ( explosives <= 7 and (has("bbust") or has("ggrab")) ) then
-        logic = 7 -- FIXIT you don't need small elevation; you can jump up the barrel and then into the room without tall jump
     end
     
     return convertLogic(logic, skip)

--- a/scripts/logic/logic_overhead.lua
+++ b/scripts/logic/logic_overhead.lua
@@ -2192,5 +2192,6 @@ Mia's List of Known Bugs in the AP Logic:
 - [Grunty Industries - Connector between outside back and floor 4] You don't need tall jump to make the jumps if you have arat
 - [Grunty Industries - egg nests by floor 4 fire escape] You can collect them with just arat
 - [Hailfire Peaks - Treble] you can get it with clockworks instead of grenade eggs for the clawbts strategy
+- [Hailfire Peaks - Stomping Plains Jiggy] you don't need tall jump if you have pack whack
 
 --]]

--- a/scripts/logic/logic_regionconnectors.lua
+++ b/scripts/logic/logic_regionconnectors.lua
@@ -1674,15 +1674,17 @@ function connector_GIOBack_to_GIF4(skip)
     elif self.world.options.logic_type == LogicType.option_easy_tricks:
         logic = self.claw_clamber_boots(state) and (self.flutter(state) or self.air_rat_a_tat_rap(state)) and self.small_elevation(state)
     elif self.world.options.logic_type == LogicType.option_hard_tricks:
-        logic = self.claw_clamber_boots(state) and (self.flutter(state) or self.air_rat_a_tat_rap(state)) and self.small_elevation(state)
+        logic = self.claw_clamber_boots(state) and (self.flutter(state) or self.air_rat_a_tat_rap(state) and self.small_elevation(state))
     elif self.world.options.logic_type == LogicType.option_glitches:
-        logic = self.claw_clamber_boots(state) and (self.flutter(state) or self.air_rat_a_tat_rap(state)) and self.small_elevation(state)
+        logic = self.claw_clamber_boots(state) and (self.flutter(state) or self.air_rat_a_tat_rap(state) and self.small_elevation(state))
     --]]
     
     if ( has("clawbts") and can_reachSmallElevation() and (has("flutter") or has("arat")) ) then
         logic = 1
+    elseif ( has("clawbts") and has("flutter") ) then
+        logic = 2
     elseif ( has("clawbts") and has("arat") ) then
-        logic = 7 -- FIXIT you don't need tall jump to get to floor 4 from the fire escape if you have arat
+        logic = 7 -- apparently you don't need it with arat either
     end
     
     return convertLogic(logic, skip)


### PR DESCRIPTION
# v0.10.1

**Changes**
- Updated logic for v4.6.1 of Banjo-Tooie AP.

**Fixes**
- Backtracking from Terry's nest is now properly accounted for instead of spitting you out into an incorrect world.

**Known Issues**
- Warp Silos are not auto-tracked if Randomized Silos setting is disabled (though this should not cause logic issues).
- Green Targitzan Relics, Big Top Tickets, and Beans are not auto-tracked when not randomized.
- Collected locations do not reset when reloading the tracker until connecting to an AP room.