### PR TITLE
v0.10.3

### DIFF
--- a/locations/locations_hailfire.json
+++ b/locations/locations_hailfire.json
@@ -1800,7 +1800,7 @@
         "chest_unopened_img": "/images/locations/eggnest.png",
         "chest_opened_img": "/images/locations/eggnest2.png",
         "visibility_rules": ["nestsanity_on"],
-        "access_rules": ["^$treble_HFP"],
+        "access_rules": ["^$nests_HFP_icicleGrottoTop"],
         "sections": [
           {
             "name": "Egg Nest 1"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Banjo-Tooie",
     "game_name": "Banjo-Tooie",
-    "package_version": "0.10.2",
+    "package_version": "0.10.3",
     "package_uid": "ap_banjotooie",
     "author": "Ozone, MiaSchemes",
     "variants": {

--- a/scripts/logic/logic__glittergulch.lua
+++ b/scripts/logic/logic__glittergulch.lua
@@ -44,6 +44,21 @@ function access_GGM_ttrot(skip)
         logic = 0
     elseif ( has("ttrain") or has("springb") ) then
         logic = 1
+    else
+        -- this is truly cursed, but doable! smuggling talon trot into MT and bringing them to GGM through the prospector's hut
+        local mtpcAccessibility = Tracker:FindObjectForCode("@Region: Mayahem Temple - Prison Compound").AccessibilityLevel
+        
+        if ( mtpcAccessibility > AccessibilityLevel.None ) then
+            if ( has("ttrain") and has("mta") and load_mt_mt() ) then
+                logic = 7 -- smuggle ttrain from spiral mountain
+            elseif ( has("clawbts") and (has("jra") and load_jrl_mt() or has("hfa") and load_hfp_mt() or has("gga") and load_ggm_mt() or connector_PL_to_PG(true) <= 7 and load_ww_mt() and has("wwa")) ) then
+                logic = 7 -- smuggle clawbts from cliff top
+            elseif ( has("springb") and (has("tda") and load_tdl_mt() or has("cca") and load_ccl_mt()) ) then
+                logic = 7 -- smuggle springb from wasteland
+            elseif ( has("clawbts") and (has("gia") and load_gi_mt() or has("cka") and load_ck_mt()) ) then
+                logic = 7 -- smuggle clawbts from quagmire
+            end
+        end
     end
     
     return convertLogic(logic, skip)
@@ -422,6 +437,8 @@ function jiggy_GGM_generatorCavern(skip)
     -- Sequence Breaking
     elseif ( has_legSpring() or has("tjump") and has_packWhack() and has("climb") ) then
         logic = math.max(1, canBreakBoulders)
+    else
+        logic = math.max(7, access_GGM_ttrot(true)) -- smuggling talon trot is all you need
     end
     
     return convertLogic(logic, skip)
@@ -1039,6 +1056,8 @@ function nests_GGM_outsidePowerHut(skip)
     -- Sequence Breaking
     elseif ( has("bbust") or has("ttrain") or has("splitup") or clockwork_shot() ) then
         logic = math.max(2, canBreakBoulders)
+    else
+        logic = math.max(7, canBreakBoulders, access_GGM_ttrot(true)) -- smuggling talon trot is enough if you can get past the boulders
     end
     
     return convertLogic(logic, skip)
@@ -1063,6 +1082,8 @@ function nests_GGM_mumbo(skip)
         logic = 1
     elseif ( can_clockworkShot() ) then
         logic = 2
+    else
+        logic = math.max(7, access_GGM_ttrot(true)) -- smuggle talon trot
     end
     
     return convertLogic(logic, skip)
@@ -1123,6 +1144,8 @@ function nests_GGM_canaryCaveHigh(skip)
     -- Sequence Breaking
     elseif ( can_reachSmallElevation() or has("ggrab") or can_clockworkShot() ) then
         logic = math.max(2, humba)
+    else
+        logic = math.max(7, humba, access_GGM_ttrot(true)) -- again, smuggle talon trot
     end
     
     return convertLogic(logic, skip)

--- a/scripts/logic/logic__gruntyindustries.lua
+++ b/scripts/logic/logic__gruntyindustries.lua
@@ -1405,7 +1405,7 @@ function nests_GI_floor1HighPipe(skip)
         logic = 0
     elseif ( (gi2Accessibility == AccessibilityLevel.Normal or gi2Accessibility == AccessibilityLevel.Cleared) and (floor2SplitUp <= logictype.CurrentStage and has_legSpring() or f2tof1 <= logictype.CurrentStage and has("tjump")) or has("clawbts") and (has_wingWhack() or has_glide() and has("eggaim")) ) then
         logic = 1
-	elseif ( has("clawbts") ) then
+    elseif ( has("clawbts") ) then
         logic = 2
     
     -- Sequence Breaking
@@ -2872,20 +2872,18 @@ end
 function honeycomb_GI_trainStation(skip)
     local logic = 99
     --[[        honeycomb_gi_station
-    if self.world.options.logic_type == LogicType.option_intended:
+     if self.intended_logic(state):
         logic = self.grip_grab(state) and self.ground_attack(state) and self.spring_pad(state)
-    elif self.world.options.logic_type == LogicType.option_easy_tricks:
-        logic = self.ground_attack(state) and self.spring_pad(state)
-    elif self.world.options.logic_type == LogicType.option_hard_tricks:
+    elif self.easy_tricks_logic(state):
+        logic = self.ground_attack(state) and self.spring_pad(state) and self.grip_grab(state)
+    elif self.hard_tricks_logic(state):
         logic = (self.ground_attack(state) and self.spring_pad(state)) or self.clockwork_shot(state) or self.leg_spring(state)
-    elif self.world.options.logic_type == LogicType.option_glitches:
+    elif self.glitches_logic(state):
         logic = (self.ground_attack(state) and self.spring_pad(state)) or self.clockwork_shot(state) or self.leg_spring(state)
-    --]]
+     --]]
     
     if ( has("ggrab") and can_groundAttack() and has("tjump") ) then
         logic = 0
-    elseif ( can_groundAttack() and has("tjump") ) then
-        logic = 1
     elseif ( can_clockworkShot() or has_legSpring() ) then
         logic = 2
     end

--- a/scripts/logic/logic__hailfire.lua
+++ b/scripts/logic/logic__hailfire.lua
@@ -421,11 +421,11 @@ function jiggy_HFP_dragonBrothers(skip)
                     )
      --]]
     
-    local hfpiAccessibility = Tracker:FindObjectForCode("@Region: Hailfire Peaks - Icy Side").AccessibilityLevel
+    local chillyWillyAccessibility = Tracker:FindObjectForCode("@Region: Boss Arena - Chilly Willy").AccessibilityLevel
     
-    if ( has("feggs") and has("ieggs") and has("eggshoot") and has("climb") and (has("tjump") or has("ttrot")) and (hfpiAccessibility == AccessibilityLevel.Normal or hfpiAccessibility == AccessibilityLevel.Cleared) ) then
+    if ( has("feggs") and has("ieggs") and has("eggshoot") and has("climb") and (has("tjump") or has("ttrot")) and (chillyWillyAccessibility == AccessibilityLevel.Normal or chillyWillyAccessibility == AccessibilityLevel.Cleared) ) then
         logic = 0
-    elseif ( has("feggs") and has("ieggs") and has("eggshoot") and (has("fflip") or has("ggrab")) and (has("tjump") or has("ttrot")) and (hfpiAccessibility == AccessibilityLevel.Normal or hfpiAccessibility == AccessibilityLevel.Cleared) ) then
+    elseif ( has("feggs") and has("ieggs") and has("eggshoot") and (has("fflip") or has("ggrab")) and (has("tjump") or has("ttrot")) and (chillyWillyAccessibility == AccessibilityLevel.Normal or chillyWillyAccessibility == AccessibilityLevel.Cleared) ) then
         logic = 1
     elseif ( has("randomizebossentrances_off") and has("feggs") and has("ieggs") and has("fpad") and has("eggshoot") and has_packWhack() and (has("tjump") or has("ttrot")) and (has("climb") or has("fflip") or has("ggrab")) and (has("clawbts") or (has("tjump") and has("roll") or has("ttrot")) and (has("flutter") or has("arat")) and has("ggrab")) ) then
         logic = 2
@@ -437,27 +437,27 @@ end
 function jiggy_HFP_volcano(skip)
     local logic = 99
     --[[        jiggy_volcano
-    if self.world.options.logic_type == LogicType.option_intended:
+     if self.intended_logic(state):
         logic = self.long_jump(state) and self.hfp_top(state)
-    elif self.world.options.logic_type == LogicType.option_easy_tricks:
-        logic = self.long_jump(state) and self.hfp_top(state) or self.split_up(state)
-    elif self.world.options.logic_type == LogicType.option_hard_tricks:
-        logic = self.long_jump(state) and self.hfp_top(state) or self.split_up(state)
-    elif self.world.options.logic_type == LogicType.option_glitches:
-        logic = self.long_jump(state) and self.hfp_top(state) or self.split_up(state)
-    --]]
+    elif self.easy_tricks_logic(state):
+        logic = (self.long_jump(state) or self.tall_jump(state)) and self.hfp_top(state) or self.split_up(state)
+    elif self.hard_tricks_logic(state):
+        logic = (self.long_jump(state) or self.tall_jump(state)) and self.hfp_top(state) or self.split_up(state)
+    elif self.glitches_logic(state):
+        logic = (self.long_jump(state) or self.tall_jump(state)) and self.hfp_top(state) or self.split_up(state)
+     --]]
     
     local top = access_HFP_lavaSideTop(true)
     
     -- Normal Logic
     if ( can_longJump() and top <= logictype.CurrentStage ) then
         logic = 0
-    elseif ( has("splitup") ) then
+    elseif ( has("splitup") or has("tjump") and top <= logictype.CurrentStage ) then
         logic = 1
     
     -- Sequence Breaking
-    elseif ( can_longJump() ) then
-        logic = top
+    elseif ( can_longJump() or has("tjump") ) then
+        logic = math.max(1, top)
     end
     
     return convertLogic(logic, skip)
@@ -1019,72 +1019,6 @@ function notes_HFP_icySideBoggy(skip)
     return convertLogic(logic, skip)
 end
 
-function notes_HFP_icicleGrottoTop(skip)
-    local logic = 99
-    --[[        nest_icicle_grotto_top
-    if self.world.options.logic_type == LogicType.option_intended:
-        logic = self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state) and (self.talon_trot(state) or self.split_up(state))
-    elif self.world.options.logic_type == LogicType.option_easy_tricks:
-        logic = (self.split_up(state) and self.ice_cube_kazooie(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\           -- checking for split up is redundant when ice_cube_kazooie requires it
-                or (self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state) and (self.talon_trot(state) or self.split_up(state)))\
-                or self.claw_clamber_boots(state) and self.grenade_eggs(state) and self.egg_aim(state)
-    elif self.world.options.logic_type == LogicType.option_hard_tricks:
-        logic = (self.split_up(state) and self.ice_cube_kazooie(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\
-                or (self.hfp_top(state) and (self.grenade_eggs(state) or self.clockwork_shot(state))\
-                    and self.egg_aim(state) and self.spring_pad(state) and (self.talon_trot(state) or self.split_up(state)))\
-                or (self.extremelyLongJump(state) and self.clockwork_shot(state))\
-                or self.claw_clamber_boots(state) and self.ice_cube_BK(state)
-    elif self.world.options.logic_type == LogicType.option_glitches:
-        logic = (self.split_up(state) and self.ice_cube_kazooie(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\
-                or (self.hfp_top(state) and (self.grenade_eggs(state) or self.clockwork_shot(state))\
-                    and self.egg_aim(state) and self.spring_pad(state) and (self.talon_trot(state) or self.split_up(state)))\
-                or (self.extremelyLongJump(state) and self.clockwork_shot(state))\
-                or self.claw_clamber_boots(state) and self.ice_cube_BK(state)
-     --]]
-    
-    local top = access_HFP_lavaSideTop(true)
-    local soloKazooieCube = access_HFP_canBreakIceCubesAsSoloKazooie(true)
-    local extremelyLongJump = can_extremelyLongJump(true)
-    local pairCube = access_HFP_canBreakIceCubesAsPair(true)
-    
-    -- Normal Logic
-    if ( top <= logictype.CurrentStage and can_shootEggs("geggs") and has("eggaim") and has("tjump") and (has("ttrot") or has("splitup")) ) then
-        logic = 0
-    elseif ( soloKazooieCube <= logictype.CurrentStage and (has("tjump") or has_wingWhack() or has_glide() or has_legSpring()) or has("clawbts") and can_shootEggs("geggs") and has("eggaim") ) then
-        logic = 1
-    elseif ( top < 2 and can_shootEggs("geggs") and has("eggaim") and has("tjump") and (has("ttrot") or has("splitup")) ) then
-        logic = 1 -- Sequence Breaking
-    elseif ( top <= logictype.CurrentStage and can_clockworkShot() and has("tjump") and (has("ttrot") or has("splitup")) or extremelyLongJump <= logictype.CurrentStage and can_clockworkShot() or has("clawbts") and pairCube <= logictype.CurrentStage ) then
-        logic = 2
-    
-    -- Sequence Breaking
-    else
-        local fromTop = 99
-        if ( (can_shootEggs("geggs") and has("eggaim") or can_clockworkShot()) and has("tjump") and (has("ttrot") or has("splitup")) ) then
-            fromTop = math.max(2, top)
-        end
-        
-        local clockworkJump = 99
-        if ( can_clockworkShot() ) then
-            clockworkJump = math.max(2, extremelyLongJump)
-        end
-        
-        local soloKazooie = 99
-        if ( has("tjump") or has_wingWhack() or has_glide() or has_legSpring() ) then
-            soloKazooie = math.max(1, soloKazooieCube)
-        end
-        
-        local clawbts = 99
-        if ( has("clawbts") ) then
-            clawbts = math.max(2, pairCube)
-        end
-        
-        logic = math.min(fromTop, clockworkJump, soloKazooie, clawbts)
-    end
-    
-    return convertLogic(logic, skip)
-end
-
 ----- Nests
 
 function nests_HFP_lavaSideOnShelterAtEntrance(skip)
@@ -1153,51 +1087,6 @@ function nests_HFP_icySideTrainStationHard(skip)
     -- Sequence Breaking
     else
         logic = accessIcyTrainStation
-    end
-    
-    return convertLogic(logic, skip)
-end
-
-function nests_HFP_lavaSideChillyBilli(skip)
-    local logic = 99
-    --[[
-    self.flight_pad(state) and self.ice_eggs_item(state)
-    --]]
-    
-    if ( has("fpad") and has("ieggs") ) then
-        logic = 0
-    end
-    
-    return convertLogic(logic, skip)
-end
-
-function nests_HFP_icySideChillyWilly(skip)
-    local logic = 99
-    --[[
-    if self.world.options.logic_type == LogicType.option_intended:
-        logic = self.fire_eggs(state) and self.claw_clamber_boots(state)
-    elif self.world.options.logic_type == LogicType.option_easy_tricks:
-        logic = self.fire_eggs(state) and self.claw_clamber_boots(state)
-    elif self.world.options.logic_type == LogicType.option_hard_tricks:
-        # In case people go for the damage boost for Chilly Willy then die before getting the jiggy, we also require Pack Whack to prevent softlocks.
-        logic = self.claw_clamber_boots(state)\
-                 or (self.pack_whack(state) and self.tall_jump(state) and self.flutter(state) and \
-                     (self.talon_trot(state) or self.flap_flip(state)))
-    elif self.world.options.logic_type == LogicType.option_glitches:
-        # In case people go for the damage boost for Chilly Willy then die before getting the jiggy, we also require Pack Whack to prevent softlocks.
-        logic = self.claw_clamber_boots(state)\
-                 or (self.pack_whack(state) and self.tall_jump(state) and self.flutter(state) and \
-                     (self.talon_trot(state) or self.flap_flip(state)))
-    --]]
-    
-    -- Normal Logic
-    if ( can_shootEggs("feggs") and has("clawbts") ) then
-        logic = 0
-    elseif ( has("clawbts") or has_packWhack() and has("tjump") and has("flutter") and (has("ttrot") or has("fflip")) ) then
-        logic = 2
-        
-    -- Sequence Breaking
-        
     end
     
     return convertLogic(logic, skip)
@@ -1342,6 +1231,74 @@ function nests_HFP_icicleGrottoSpringPad(skip)
     return convertLogic(logic, skip)
 end
 
+function nests_HFP_icicleGrottoTop(skip)
+    local logic = 99
+    --[[        nest_icicle_grotto_top
+    if self.world.options.logic_type == LogicType.option_intended:
+        logic = self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state) and (self.talon_trot(state) or self.split_up(state))
+    elif self.world.options.logic_type == LogicType.option_easy_tricks:
+        logic = (self.split_up(state) and self.ice_cube_kazooie(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\           -- checking for split up is redundant when ice_cube_kazooie requires it
+                or (self.hfp_top(state) and self.grenade_eggs(state) and self.egg_aim(state) and self.spring_pad(state) and (self.talon_trot(state) or self.split_up(state)))\
+                or self.claw_clamber_boots(state) and self.grenade_eggs(state) and self.egg_aim(state)
+    elif self.world.options.logic_type == LogicType.option_hard_tricks:
+        logic = (self.split_up(state) and self.ice_cube_kazooie(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\
+                or (self.hfp_top(state) and (self.grenade_eggs(state) or self.clockwork_shot(state))\
+                    and self.egg_aim(state) and self.spring_pad(state) and (self.talon_trot(state) or self.split_up(state)))\
+                or (self.extremelyLongJump(state) and self.clockwork_shot(state))\
+                or self.claw_clamber_boots(state) and self.ice_cube_BK(state)
+    elif self.world.options.logic_type == LogicType.option_glitches:
+        logic = (self.split_up(state) and self.ice_cube_kazooie(state) and (self.tall_jump(state) or self.wing_whack(state) or self.glide(state) or self.leg_spring(state)))\
+                or (self.hfp_top(state) and (self.grenade_eggs(state) or self.clockwork_shot(state))\
+                    and self.egg_aim(state) and self.spring_pad(state) and (self.talon_trot(state) or self.split_up(state)))\
+                or (self.extremelyLongJump(state) and self.clockwork_shot(state))\
+                or self.claw_clamber_boots(state) and self.ice_cube_BK(state)
+     --]]
+    
+    local top = access_HFP_lavaSideTop(true)
+    local soloKazooieCube = access_HFP_canBreakIceCubesAsSoloKazooie(true)
+    local extremelyLongJump = can_extremelyLongJump(true)
+    local pairCube = access_HFP_canBreakIceCubesAsPair(true)
+    
+    -- Normal Logic
+    if ( top <= logictype.CurrentStage and can_shootEggs("geggs") and has("eggaim") and has("tjump") and (has("ttrot") or has("splitup")) ) then
+        logic = 0
+    elseif ( soloKazooieCube <= logictype.CurrentStage and (has("tjump") or has_wingWhack() or has_glide() or has_legSpring()) or has("clawbts") and can_shootEggs("geggs") and has("eggaim") ) then
+        logic = 1
+    elseif ( top < 2 and can_shootEggs("geggs") and has("eggaim") and has("tjump") and (has("ttrot") or has("splitup")) ) then
+        logic = 1 -- Sequence Breaking
+    elseif ( top <= logictype.CurrentStage and can_clockworkShot() and has("tjump") and (has("ttrot") or has("splitup")) or extremelyLongJump <= logictype.CurrentStage and can_clockworkShot() or has("clawbts") and pairCube <= logictype.CurrentStage ) then
+        logic = 2
+    
+    -- Sequence Breaking
+    else
+        local fromTop = 99
+        if ( (can_shootEggs("geggs") and has("eggaim") or can_clockworkShot()) and has("tjump") and (has("ttrot") or has("splitup")) ) then
+            fromTop = math.max(2, top)
+        end
+        
+        local clockworkJump = 99
+        if ( can_clockworkShot() ) then
+            clockworkJump = math.max(2, extremelyLongJump)
+        end
+        
+        local soloKazooie = 99
+        if ( has("tjump") or has_wingWhack() or has_glide() or has_legSpring() ) then
+            soloKazooie = math.max(1, soloKazooieCube)
+        elseif ( has("clawbts") ) then
+            soloKazooie = math.max(7, soloKazooieCube)
+        end
+        
+        local clawbts = 99
+        if ( has("clawbts") ) then
+            clawbts = math.max(2, pairCube)
+        end
+        
+        logic = math.min(fromTop, clockworkJump, soloKazooie, clawbts)
+    end
+    
+    return convertLogic(logic, skip)
+end
+
 ----- Signs
 
 ----- Other - Jinjos
@@ -1448,6 +1405,8 @@ function jinjo_HFP_icicleGrotto(skip)
         logic = 1
     elseif ( has_legSpring() or can_clockworkShot() and has("tjump") and (has("splitup") or has("ttrot")) ) then
         logic = 2
+	elseif ( can_clockworkhot() and warp_HFP_icicleGrotto(true) <= 7 ) then
+		logic = 7 -- if you can get to the warp pad and can clockwork shot, you can do this
     end
     
     return convertLogic(logic, skip)

--- a/scripts/logic/logic__isle_and_cauldronkeep.lua
+++ b/scripts/logic/logic__isle_and_cauldronkeep.lua
@@ -32,6 +32,20 @@ function access_PL_top(skip)
     -- Sequence Breaking
     elseif ( has("clawbts") and ctAccessibility > AccessibilityLevel.None ) then
         logic = logictype.CurrentStage + 1 -- was already converted once by the json
+    else
+        -- various talon trot smugglings
+        local wwiAccessibility = Tracker:FindObjectForCode("@Region: Witchyworld - The Inferno").AccessibilityLevel
+        local ctAccessibility = Tracker:FindObjectForCode("@Region: Cliff Top").AccessibilityLevel
+        local jrlAccessibility = Tracker:FindObjectForCode("@Region: Jolly Roger's Lagoon - Main Area").AccessibilityLevel
+        local tdlAccessibility = Tracker:FindObjectForCode("@Region: Terrydactyland - Main Area").AccessibilityLevel
+        
+        if ( wwiAccessibility > AccessibilityLevel.None and has("ttrain") and (load_ww_ww() and has("wwa") or load_jrl_ww() or load_hfp_ww() and (connector_CTHFP_to_CT(true) or ctAccessibility > AccessibilityLevel.None)) ) then
+            logic = 7 -- ttrain from WW
+        elseif ( jrlAccessibility > AccessibilityLevel.None and has("ttrain") and has("doubloon", 28) and (load_ww_jrl() and has("wwa") or load_jrl_jrl() or load_hfp_jrl() and (connector_CTHFP_to_CT(true) or ctAccessibility > AccessibilityLevel.None)) ) then
+            logic = 7 -- ttrain from JRL
+        elseif ( tdlAccessibility > AccessibilityLevel.None and has("springb") and (load_ww_tdl() and has("wwa") or load_jrl_tdl() or load_hfp_tdl() and (connector_CTHFP_to_CT(true) or ctAccessibility > AccessibilityLevel.None)) ) then
+            logic = 7 -- springb from TDL
+        end
     end
     
     return convertLogic(logic, skip)
@@ -53,28 +67,30 @@ function access_PL_canReachHoneyB(skip)
                 or state.can_reach_region(regionName.IOHCT, self.player) and self.claw_clamber_boots(state)
     --]]
     
+    local ctAccessibility = Tracker:FindObjectForCode("@Region: Cliff Top").AccessibilityLevel
     
     -- Normal Logic
     if ( has("ttrot") ) then
         logic = 0
+    elseif ( has("clawbts") and (ctAccessibility == AccessibilityLevel.Normal or ctAccessibility == AccessibilityLevel.Cleared) ) then
+        logic = 1
+    
+    -- Sequence Breaking
+    elseif ( has("clawbts") and ctAccessibility > AccessibilityLevel.None ) then
+        logic = logictype.CurrentStage + 1 -- was already converted once by the json
     else
-        local ctAccessibility = Tracker:FindObjectForCode("@Region: Cliff Top").AccessibilityLevel -- FIXIT I can't for the life of me get this to work if your only way to cliff top is split up. reminder to check the poptracker discord to see if anyone has suggestions
+        -- various talon trot smugglings
+        local wwiAccessibility = Tracker:FindObjectForCode("@Region: Witchyworld - The Inferno").AccessibilityLevel
+        local ctAccessibility = Tracker:FindObjectForCode("@Region: Cliff Top").AccessibilityLevel
         local jrlAccessibility = Tracker:FindObjectForCode("@Region: Jolly Roger's Lagoon - Main Area").AccessibilityLevel
         local tdlAccessibility = Tracker:FindObjectForCode("@Region: Terrydactyland - Main Area").AccessibilityLevel
-        local giAccessibility = Tracker:FindObjectForCode("@Region: Grunty Industries 1st Floor").AccessibilityLevel
-    
-        if ( has("clawbts") and (ctAccessibility == AccessibilityLevel.Normal or ctAccessibility == AccessibilityLevel.Cleared) ) then
-            logic = 1
         
-        -- Sequence Breaking
-        elseif ( has("clawbts") and ctAccessibility > AccessibilityLevel.None ) then
-            logic = logictype.CurrentStage + 1 -- was already converted once by the json
-        elseif ( (load_jrl_jrl() or load_hfp_jrl() and ctAccessibility > AccessibilityLevel.None or load_ww_jrl() and has("wwa")) and jrlAccessibility > AccessibilityLevel.None and has("doubloon", 28) and has("ttrain") ) then
-            logic = 7 -- smuggle turbo trainers from JRL, technically requires 28 doubloons
-        elseif ( (load_jrl_tdl() or load_hfp_tdl() and ctAccessibility > AccessibilityLevel.None or load_ww_tdl() and has("wwa")) and tdlAccessibility > AccessibilityLevel.None and has("springb") ) then
-            logic = 7 -- smuggle springy step shoes from TDL, requires entrance rando
-        elseif ( (load_jrl_gi() or load_hfp_gi() and ctAccessibility > AccessibilityLevel.None or load_ww_gi() and has("wwa")) and giAccessibility > AccessibilityLevel.None and has("splitup") and has("clawbts") ) then
-            logic = 7 -- smuggle claw clambers from GI, requires entrance rando, first floor access and split up to get out
+        if ( wwiAccessibility > AccessibilityLevel.None and has("ttrain") and (load_ww_ww() and has("wwa") or load_jrl_ww() or load_hfp_ww() and (connector_CTHFP_to_CT(true) or ctAccessibility > AccessibilityLevel.None)) ) then
+            logic = 7 -- ttrain from WW
+        elseif ( jrlAccessibility > AccessibilityLevel.None and has("ttrain") and has("doubloon", 28) and (load_ww_jrl() and has("wwa") or load_jrl_jrl() or load_hfp_jrl() and (connector_CTHFP_to_CT(true) or ctAccessibility > AccessibilityLevel.None)) ) then
+            logic = 7 -- ttrain from JRL
+        elseif ( tdlAccessibility > AccessibilityLevel.None and has("springb") and (load_ww_tdl() and has("wwa") or load_jrl_tdl() or load_hfp_tdl() and (connector_CTHFP_to_CT(true) or ctAccessibility > AccessibilityLevel.None)) ) then
+            logic = 7 -- springb from TDL
         end
     end
     
@@ -264,6 +280,8 @@ function notes_WL_topNearClockworkSilo(skip)
         logic = 0
     elseif ( can_clockworkShot() ) then
         logic = 2
+    elseif ( has("springb") and has("flutter") ) then
+        logic = 7 -- smuggle talon trot
     end
     
     return convertLogic(logic, skip)

--- a/scripts/logic/logic__jollyrogers.lua
+++ b/scripts/logic/logic__jollyrogers.lua
@@ -15,35 +15,35 @@ end
 function access_JRL_canEnterGIWasteDisposal(skip)
     local logic = 99
     --[[        jrl_waste_disposal
-    if self.world.options.logic_type == LogicType.option_intended:
+     if self.intended_logic(state):
         logic = (self.has_explosives(state) or self.bill_drill(state))\
                     and (self.talon_trot(state)\
-                         or self.tall_jump(state) and self.roll(state) and self.flutter(state)
+                         or self.tall_jump(state) and (self.flutter(state) or self.air_rat_a_tat_rap(state))
                     )
-    elif self.world.options.logic_type == LogicType.option_easy_tricks:
+    elif self.easy_tricks_logic(state):
         logic = (self.has_explosives(state) or self.bill_drill(state))\
                 and (self.talon_trot(state)\
-                    or self.tall_jump(state) and self.roll(state) and self.flutter(state)\
+                    or self.tall_jump(state) and (self.flutter(state) or self.air_rat_a_tat_rap(state))\
                     or state.has(itemName.DOUBLOON, self.player, 28) and self.turbo_trainers(state)
                 )
-    elif self.world.options.logic_type == LogicType.option_hard_tricks:
+    elif self.hard_tricks_logic(state):
         logic = (self.has_explosives(state) or self.bill_drill(state))\
                 and (self.talon_trot(state)\
-                    or self.tall_jump(state) and self.roll(state) and self.flutter(state)\
+                    or self.tall_jump(state) and (self.flutter(state) or self.air_rat_a_tat_rap(state))\
                     or state.has(itemName.DOUBLOON, self.player, 28) and self.turbo_trainers(state)
                 )
-    elif self.world.options.logic_type == LogicType.option_glitches:
+    elif self.glitches_logic(state):
         logic = (self.has_explosives(state) or self.bill_drill(state))\
                 and (self.talon_trot(state)\
-                    or self.tall_jump(state) and self.roll(state) and self.flutter(state)\
+                    or self.tall_jump(state) and (self.flutter(state) or self.air_rat_a_tat_rap(state))\
                     or state.has(itemName.DOUBLOON, self.player, 28) and self.turbo_trainers(state)
                 )
-    --]]
+     --]]
     
     explosives = can_shootExplosiveEggs(true)
     
     -- Normal Logic
-    if ( (explosives <= logictype.CurrentStage or has_billDrill()) and (has("ttrot") or has("tjump") and has("roll") and has("flutter")) ) then
+    if ( (explosives <= logictype.CurrentStage or has_billDrill()) and (has("ttrot") or has("tjump") and (has("flutter") or has("arat"))) ) then
         logic = 0
     elseif ( (explosives <= logictype.CurrentStage or has_billDrill()) and has("doubloon", 28) and has("ttrain") ) then
         logic = 1
@@ -51,6 +51,12 @@ function access_JRL_canEnterGIWasteDisposal(skip)
     -- Sequence Breaking
     elseif ( has("ttrot") or has("tjump") and has("roll") and has("flutter") or has("doubloon", 28) and has("ttrain") ) then
         logic = math.max(1, explosives)
+    elseif ( (explosives <= 7 or has_billDrill()) and has("clawbts") and load_jrl_jrl() and has("jra") ) then
+        logic = 7 -- smuggle clawbts from cliff top
+    elseif ( (explosives <= 7 or has_billDrill()) and has("clawbts") and (load_hfp_jrl() and has("hfa") or load_ggm_jrl() and has("gga") or connector_PL_to_PG(true) <= 7 and load_ww_jrl() and has("wwa")) ) then
+        logic = 7 -- smuggle clawbts from cliff top into hfp entrance, ggm entrance, or ww entrance
+    elseif ( (explosives <= 7 or has_billDrill()) and (has("clawbts") and (load_gi_jrl() and has("gia") or load_ck_jrl() and has("cka")) or has("springb") and (load_tdl_jrl() and has("tda") or load_ccl_jrl() and has("cca")) or has("ttrain") and load_mt_jrl() and has("mta")) ) then
+        logic = 7 -- smuggle clawbts from quagmire if GI or CK take you to JRL, or springb from wasteland if either TDL or CCL take you to JRL, or ttrain from spiral mountain if MT takes you to JRL
     end
     
     return convertLogic(logic, skip)
@@ -549,7 +555,7 @@ function jiggy_JRL_lordWooFakFak(skip)
     
     -- Normal Logic
     if ( has("auqaim") and has("geggs") ) then
-		local jrlAccessibility = Tracker:FindObjectForCode("@Region: Jolly Roger's Lagoon - Main Area").AccessibilityLevel
+        local jrlAccessibility = Tracker:FindObjectForCode("@Region: Jolly Roger's Lagoon - Main Area").AccessibilityLevel
         local humba = access_JRL_humba(true)
     
         if ( (jrlAccessibility == AccessibilityLevel.Normal or jrlAccessibility == AccessibilityLevel.Cleared) and (humba <= logictype.CurrentStage or has("mumbojr")) ) then
@@ -702,8 +708,16 @@ function notes_JRL_jollys(skip)
         logic = 1
     elseif ( can_clockworkShot() ) then
         logic = 2
-	elseif ( has("bbust") ) then
-		logic = 7 -- FIXIT tricky but doable
+    elseif ( has("bbust") ) then
+        logic = 7 -- FIXIT tricky but doable
+    elseif ( has("doubloon", 28) and has("ttrain") ) then
+        logic = 7 -- smuggle talon trot from JRL
+    elseif ( has("clawbts") and load_jrl_jrl() and has("jra") ) then
+        logic = 7 -- smuggle clawbts from cliff top
+    elseif ( has("clawbts") and (load_hfp_jrl() and has("hfa") or load_ggm_jrl() and has("gga") or connector_PL_to_PG(true) <= 7 and load_ww_jrl() and has("wwa")) ) then
+        logic = 7 -- smuggle clawbts from cliff top into hfp entrance, ggm entrance, or ww entrance
+    elseif ( has("clawbts") and (load_gi_jrl() and has("gia") or load_ck_jrl() and has("cka")) or has("springb") and (load_tdl_jrl() and has("tda") or load_ccl_jrl() and has("cca")) or has("ttrain") and load_mt_jrl() and has("mta") ) then
+        logic = 7 -- smuggle clawbts from quagmire if GI or CK take you to JRL, or springb from wasteland if either TDL or CCL take you to JRL, or ttrain from spiral mountain if MT takes you to JRL
     end
     
     return convertLogic(logic, skip)
@@ -906,21 +920,23 @@ end
 function nests_JRL_seaweedSanctumBottom(skip)
     local logic = 99
     --[[        nest_seaweed_bottom
-    if self.world.options.logic_type == LogicType.option_intended:
+     if self.intended_logic(state):
         logic = self.flap_flip(state)
-    elif self.world.options.logic_type == LogicType.option_easy_tricks:
+    elif self.easy_tricks_logic(state):
         logic = self.flap_flip(state)
-    elif self.world.options.logic_type == LogicType.option_hard_tricks:
+    elif self.hard_tricks_logic(state):
         logic = self.flap_flip(state)\
-                or self.clockwork_shot(state)
-    elif self.world.options.logic_type == LogicType.option_glitches:
+                or self.clockwork_shot(state)\
+                or self.tall_jump(state) and self.beak_buster(state)
+    elif self.glitches_logic(state):
         logic = self.flap_flip(state)\
-                or self.clockwork_shot(state)
-    --]]
+                or self.clockwork_shot(state)\
+                or self.tall_jump(state) and self.beak_buster(state)
+     --]]
     
     if ( has("fflip") ) then
         logic = 0
-    elseif ( can_clockworkShot() ) then
+    elseif ( can_clockworkShot() or has("tjump") and has("bbust") ) then
         logic = 2
     end
     

--- a/scripts/logic/logic__mayahem.lua
+++ b/scripts/logic/logic__mayahem.lua
@@ -262,22 +262,25 @@ end
 function jiggy_MT_targitzan(skip)
     local logic = 99
     --[[        jiggy_targitzan
-     if self.world.options.logic_type == LogicType.option_intended:
+     if self.intended_logic(state):
       logic = self.blue_eggs_item(state) or self.fire_eggs_item(state) or self.grenade_eggs_item(state)
-    elif self.world.options.logic_type == LogicType.option_easy_tricks:
-      logic = (self.blue_eggs_item(state) or self.fire_eggs_item(state) or self.grenade_eggs_item(state))\
-                or (self.ice_eggs_item(state) and self.beak_bayonet(state))
-    elif self.world.options.logic_type == LogicType.option_hard_tricks:
-      logic = (self.blue_eggs_item(state) or self.fire_eggs_item(state) or self.grenade_eggs_item(state))\
-                or (self.ice_eggs_item(state) and self.beak_bayonet(state))
-    elif self.world.options.logic_type == LogicType.option_glitches:
-      logic = (self.blue_eggs_item(state) or self.fire_eggs_item(state) or self.grenade_eggs_item(state))\
-                or (self.ice_eggs_item(state) and self.beak_bayonet(state))
+    elif self.easy_tricks_logic(state):
+      logic = (self.blue_eggs_item(state) or self.fire_eggs_item(state))\
+                or (self.ice_eggs_item(state) and self.beak_bayonet(state))\
+                or (self.grenade_eggs_item(state) and (self.ice_eggs_item(state) or self.beak_bayonet(state)))
+    elif self.hard_tricks_logic(state):
+      logic = (self.blue_eggs_item(state) or self.fire_eggs_item(state))\
+                or (self.ice_eggs_item(state) and self.beak_bayonet(state))\
+                or (self.grenade_eggs_item(state) and (self.ice_eggs_item(state) or self.beak_bayonet(state)))
+    elif self.glitches_logic(state):
+      logic = (self.blue_eggs_item(state) or self.fire_eggs_item(state))\
+                or (self.ice_eggs_item(state) and self.beak_bayonet(state))\
+                or (self.grenade_eggs_item(state) and (self.ice_eggs_item(state) or self.beak_bayonet(state)))
      --]]
     
-    if ( has("begg") or has("feggs") or has("geggs") ) then
+    if ( has("begg") or has("feggs") or has("geggs") and logictype.CurrentStage == 0 ) then -- FIXIT this is a bug! intended should not be fine with just grenade eggs
         logic = 0
-    elseif ( has("ieggs") and has("bbayonet") ) then
+    elseif ( has("ieggs") and (has("bbayonet") or has("geggs")) ) then
         logic = 1
     end
     
@@ -686,6 +689,12 @@ function signs_MT_nearCodeChamber(skip)
     
     if ( has("ttrot") and has("ggrab") and has("fflip") ) then
         logic = 0
+    elseif ( has("ttrain") and load_mt_mt() and has("mta") ) then
+        logic = 7 -- smuggle ttrain from spiral mountain
+    elseif ( has("clawbts") and (load_jrl_mt() and has("jra") or load_hfp_mt() and has("hfa") or load_ggm_mt() and has("gga") or connector_PL_to_PG(true) <= 7 and load_ww_mt() and has("wwa")) ) then
+        logic = 7 -- smuggle clawbts from cliff top into jrl entrance, hfp entrance, ggm entrance, or ww entrance
+    elseif ( has("clawbts") and (load_gi_mt() and has("gia") or load_ck_mt() and has("cka")) or has("springb") and (load_tdl_mt() and has("tda") or load_ccl_mt() and has("cca")) ) then
+        logic = 7 -- smuggle clawbts from quagmire if GI or CK take you to JRL, or springb from wasteland if either TDL or CCL take you to JRL, or ttrain from spiral mountain if MT takes you to JRL
     end
     
     return convertLogic(logic, skip)
@@ -879,6 +888,15 @@ function honeycomb_MT_treasureChamber(skip)
         logic = 1
     elseif ( can_clockworkShot() ) then
         logic = 2
+    elseif ( has("eggaim") or basic_MT_canUseFlightPad() and can_shootEggs() ) then
+        -- various talon trot smugglings
+        if ( has("ttrain") and load_mt_mt() and has("mta") ) then
+            logic = 7 -- smuggle ttrain from spiral mountain
+        elseif ( has("clawbts") and (load_jrl_mt() and has("jra") or load_hfp_mt() and has("hfa") or load_ggm_mt() and has("gga") or connector_PL_to_PG(true) <= 7 and load_ww_mt() and has("wwa")) ) then
+            logic = 7 -- smuggle clawbts from cliff top into jrl entrance, hfp entrance, ggm entrance, or ww entrance
+        elseif ( has("clawbts") and (load_gi_mt() and has("gia") or load_ck_mt() and has("cka")) or has("springb") and (load_tdl_mt() and has("tda") or load_ccl_mt() and has("cca")) ) then
+            logic = 7 -- smuggle clawbts from quagmire if GI or CK take you to JRL, or springb from wasteland if either TDL or CCL take you to JRL, or ttrain from spiral mountain if MT takes you to JRL
+        end
     end
     
     return convertLogic(logic, skip)
@@ -966,6 +984,15 @@ function cheato_MT_jadeSnakeGrove(skip)
         logic = 0
     elseif ( can_clockworkShot() ) then
         logic = 2
+    elseif ( has("ggrab") and has("fflip") ) then
+        -- various talon trot smugglings
+        if ( has("ttrain") and load_mt_mt() and has("mta") ) then
+            logic = 7 -- smuggle ttrain from spiral mountain
+        elseif ( has("clawbts") and (load_jrl_mt() and has("jra") or load_hfp_mt() and has("hfa") or load_ggm_mt() and has("gga") or connector_PL_to_PG(true) <= 7 and load_ww_mt() and has("wwa")) ) then
+            logic = 7 -- smuggle clawbts from cliff top into jrl entrance, hfp entrance, ggm entrance, or ww entrance
+        elseif ( has("clawbts") and (load_gi_mt() and has("gia") or load_ck_mt() and has("cka")) or has("springb") and (load_tdl_mt() and has("tda") or load_ccl_mt() and has("cca")) ) then
+            logic = 7 -- smuggle clawbts from quagmire if GI or CK take you to MT, or springb from wasteland if either TDL or CCL take you to MT, or ttrain from spiral mountain if MT takes you to MT
+        end
     end
     
     return convertLogic(logic, skip)

--- a/scripts/logic/logic__terrydactyland.lua
+++ b/scripts/logic/logic__terrydactyland.lua
@@ -206,6 +206,15 @@ function access_TDL_flightPad(skip)
     -- Sequence Breaking
     elseif ( has("fpad") and (has("springb") or has("ttrot") and has("flutter")) ) then
         logic = canBeatTerry
+    elseif ( has("fpad") and (has("ttrain") and has("flutter")) ) then
+        logic = math.max(7, canBeatTerry) -- smuggle talon trot
+    elseif ( has("fpad") and has("flutter") ) then
+        -- other various talon trot smugglings
+        if ( has("clawbts") and (load_jrl_tdl() and has("jra") or load_hfp_tdl() and has("hfa") or load_ggm_tdl() and has("gga") or connector_PL_to_PG(true) <= 7 and load_ww_tdl() and has("wwa")) ) then
+            logic = 7 -- smuggle clawbts from cliff top into jrl entrance, hfp entrance, ggm entrance, or ww entrance
+        elseif ( has("clawbts") and (load_gi_tdl() and has("gia") or load_ck_tdl() and has("cka")) ) then
+            logic = 7 -- smuggle clawbts from quagmire if GI or CK take you to TDL
+        end
     end
     
     return convertLogic(logic, skip)
@@ -815,6 +824,13 @@ function jiggy_TDL_stompingPlainsAsDuo(skip)
         logic = 2
     elseif ( has("wwing") or (has("randomizewarppads_off") or has("warptl2") and (has("warptl1") or has("warptl3") or has("warptl4"))) and (has("springb") or has("ttrain")) ) then
         logic = 7 -- wonderwing, or smuggling talon trot
+    elseif ( has("randomizewarppads_off") or has("warptl2") and (has("warptl1") or has("warptl3") or has("warptl4")) ) then
+        -- other various talon trot smugglings
+        if ( has("clawbts") and (load_jrl_tdl() and has("jra") or load_hfp_tdl() and has("hfa") or load_ggm_tdl() and has("gga") or connector_PL_to_PG(true) <= 7 and load_ww_tdl() and has("wwa")) ) then
+            logic = 7 -- smuggle clawbts from cliff top into jrl entrance, hfp entrance, ggm entrance, or ww entrance
+        elseif ( has("clawbts") and (load_gi_tdl() and has("gia") or load_ck_tdl() and has("cka")) ) then
+            logic = 7 -- smuggle clawbts from quagmire if GI or CK take you to TDL
+        end
     end
     
     return convertLogic(logic, skip)
@@ -1101,8 +1117,15 @@ function nests_TDL_wallWithHoles(skip)
         logic = 2
     
     -- Sequence Breaking
-    else
+    elseif ( humba <= 7 ) then
         logic = math.max(1, humba)
+    else
+        -- other various talon trot smugglings
+        if ( has("clawbts") and (load_jrl_tdl() and has("jra") or load_hfp_tdl() and has("hfa") or load_ggm_tdl() and has("gga") or connector_PL_to_PG(true) <= 7 and load_ww_tdl() and has("wwa")) ) then
+            logic = 7 -- smuggle clawbts from cliff top into jrl entrance, hfp entrance, ggm entrance, or ww entrance
+        elseif ( has("clawbts") and (load_gi_tdl() and has("gia") or load_ck_tdl() and has("cka")) ) then
+            logic = 7 -- smuggle clawbts from quagmire if GI or CK take you to TDL
+        end
     end
     
     return convertLogic(logic, skip)
@@ -1391,28 +1414,39 @@ end
 function nests_TDL_stompingPlainsFootprint(skip)
     local logic = 99
     --[[        nest_stomping_plains_footprint
-    if self.world.options.logic_type == LogicType.option_intended:
+     if self.intended_logic(state):
         logic = self.tall_jump(state) and self.split_up(state)\
                 or self.snooze_pack(state)\
                 or self.talon_trot(state)
-    elif self.world.options.logic_type == LogicType.option_easy_tricks:
+    elif self.easy_tricks_logic(state):
         logic = self.tall_jump(state) and self.split_up(state)\
                 or self.snooze_pack(state)\
                 or self.talon_trot(state)
-    elif self.world.options.logic_type == LogicType.option_hard_tricks:
-        logic = self.tall_jump(state) and self.split_up(state)\
+    elif self.hard_tricks_logic(state):
+        logic = self.tall_jump(state)\
                 or self.snooze_pack(state)\
                 or self.talon_trot(state)
-    elif self.world.options.logic_type == LogicType.option_glitches:
-        logic = self.tall_jump(state) and self.split_up(state)\
+    elif self.glitches_logic(state):
+        logic = self.tall_jump(state)\
                 or self.snooze_pack(state)\
                 or self.talon_trot(state)
-    --]]
+     --]]
     
     if ( has("tjump") and has("splitup") or has_snoozePack() or has("ttrot") ) then
         logic = 0
+    elseif ( has("tjump") ) then
+        logic = 2
     elseif ( has("wwing") ) then
         logic = 7
+    elseif ( has("springb") and (has("randomizewarppads_off") or has("warptl2") and (has("warptl1") or has("warptl3") or has("warptl4"))) ) then
+        logic = 7 -- smuggle talon trot
+    elseif ( has("randomizewarppads_off") or has("warptl2") and (has("warptl1") or has("warptl3") or has("warptl4")) ) then
+        -- other various talon trot smugglings
+        if ( has("clawbts") and (load_jrl_tdl() and has("jra") or load_hfp_tdl() and has("hfa") or load_ggm_tdl() and has("gga") or connector_PL_to_PG(true) <= 7 and load_ww_tdl() and has("wwa")) ) then
+            logic = 7 -- smuggle clawbts from cliff top into jrl entrance, hfp entrance, ggm entrance, or ww entrance
+        elseif ( has("clawbts") and (load_gi_tdl() and has("gia") or load_ck_tdl() and has("cka")) ) then
+            logic = 7 -- smuggle clawbts from quagmire if GI or CK take you to TDL
+        end
     end
     
     return convertLogic(logic, skip)
@@ -1647,7 +1681,7 @@ function jinjo_TDL_stompingPlains(skip)
     if ( has("splitup") and has("tjump") ) then
         logic = 0
     elseif ( can_eggBarge() and (has("tjump") or has("ttrot") or has("springb") or has("ttrain")) ) then
-        logic = 3
+        logic = 3 -- FIXIT this assumes you can warp springb to stomping plains
     end
     
     return convertLogic(logic, skip)

--- a/scripts/logic/logic_regionconnectors.lua
+++ b/scripts/logic/logic_regionconnectors.lua
@@ -1386,7 +1386,7 @@ function connector_TDL_to_TDLIMTop(skip)
                 and (self.tall_jump(state) or self.beak_buster(state) or self.grip_grab(state))
      --]]
     
-    if ( has("fpad") and (has("warptl3") or has("ggrab")) ) then
+    if ( has("fpad") and (has("tjump") or has("ggrab")) ) then
         logic = 0
     elseif ( has("fpad") and has("bbust") ) then
         logic = 1


### PR DESCRIPTION
# v0.10.3

**Changes**
- Updated logic for v4.8 of Banjo-Tooie AP.

**Fixes**
- Fixed the region connection logic from TDL's main area to the top of the inside of the mountain.
- Fixed the Dragon Brothers Jiggy incorrectly checking for HFP Icy Side access instead of access to Chilly Willy's arena.
- Fixed the nests at the top of Icicle Grotto checking for the Treble Clef logic instead of their own.

**Known Issues**
- Warp Silos are not auto-tracked if Randomized Silos setting is disabled (this should not cause logic issues).
- Green Targitzan Relics, Big Top Tickets, and Beans are not auto-tracked when not randomized (this should not cause logic issues).
- Collected locations do not reset when reloading the tracker until connecting to an AP room.