### PR TITLE
v0.10.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Banjo-Tooie",
     "game_name": "Banjo-Tooie",
-    "package_version": "0.10.3",
+    "package_version": "0.10.4",
     "package_uid": "ap_banjotooie",
     "author": "Ozone, MiaSchemes",
     "variants": {

--- a/scripts/logic/logic__terrydactyland.lua
+++ b/scripts/logic/logic__terrydactyland.lua
@@ -169,7 +169,7 @@ function access_TDL_oogleBoogle(skip)
     elseif ( oogleBooglesOpen < 2 or (wwAccessibility == AccessibilityLevel.Normal or wwAccessibility == AccessibilityLevel.Cleared) and WW_to_TDL < 2 ) then
         logic = 1 -- Sequence Breaking
     elseif ( can_clockworkWarp() ) then
-        logic = 2 -- Normal Logic
+        logic = 3 -- Normal Logic
     elseif ( wwAccessibility == AccessibilityLevel.Normal or wwAccessibility == AccessibilityLevel.Cleared ) then
         logic = math.min(oogleBooglesOpen, WW_to_TDL) -- Sequence Breaking
     elseif ( wwAccessibility > AccessibilityLevel.None ) then


### PR DESCRIPTION
# v0.10.4

- Clockwork Warping into the Oogle Boogle tribe's cave is now properly shown as glitch logic, rather than hard tricks+.


# v0.10.3

**Changes**
- Updated logic for v4.8 of Banjo-Tooie AP.

**Fixes**
- Fixed the region connection logic from TDL's main area to the top of the inside of the mountain.
- Fixed the Dragon Brothers Jiggy incorrectly checking for HFP Icy Side access instead of access to Chilly Willy's arena.
- Fixed the nests at the top of Icicle Grotto checking for the Treble Clef logic instead of their own.

**Known Issues**
- Warp Silos are not auto-tracked if Randomized Silos setting is disabled (this should not cause logic issues).
- Green Targitzan Relics, Big Top Tickets, and Beans are not auto-tracked when not randomized (this should not cause logic issues).
- Collected locations do not reset when reloading the tracker until connecting to an AP room.